### PR TITLE
Adding Hooks parameter to UpdatePrecommitConfig function

### DIFF
--- a/remediation/precommit/precommitconfig_test.go
+++ b/remediation/precommit/precommitconfig_test.go
@@ -48,7 +48,11 @@ func TestUpdatePrecommitConfig(t *testing.T) {
 			log.Fatal(err)
 		}
 
-		output, err := UpdatePrecommitConfig(string(inputRequest))
+		hooks, err := GetHooks(string(inputRequest))
+		if err != nil {
+			log.Fatal(err)
+		}
+		output, err := UpdatePrecommitConfig(string(inputRequest), hooks)
 		if err != nil {
 			t.Fatalf("Error not expected: %s", err)
 		}


### PR DESCRIPTION
@varunsh-coder updated the Precommit code to contain two function, first one return the list of hooks that can be added and then the other would take these hooks as parameter to update the config file. So that if the user decide to not used some of the hooks from the list the other function would be used to update the config file accordingly.