### PR TITLE
Remove extra whitespace with Dependency Review

### DIFF
--- a/workflow-templates/dependency-review.yml
+++ b/workflow-templates/dependency-review.yml
@@ -2,7 +2,7 @@
 #
 # This Action will scan dependency manifest files that change as part of a Pull Request,
 # surfacing known-vulnerable versions of the packages declared or updated in the PR.
-# Once installed, if the workflow run is marked as required, 
+# Once installed, if the workflow run is marked as required,
 # PRs introducing known-vulnerable packages will be blocked from merging.
 #
 # Source repository: https://github.com/actions/dependency-review-action


### PR DESCRIPTION
This whitespace caused my CI checks to fail, so submitting a fix, so the next person doesn't have to push an extra change :+1: 