### PR TITLE
Add addEmptyTopLevelPermissions parameter for workflow permissions

### DIFF
--- a/remediation/workflow/secureworkflow.go
+++ b/remediation/workflow/secureworkflow.go
@@ -22,6 +22,7 @@ func SecureWorkflow(queryStringParams map[string]string, inputYaml string, svc d
 	pinnedActions, addedHardenRunner, addedPermissions, replacedMaintainedActions := false, false, false, false
 	ignoreMissingKBs := false
 	enableLogging := false
+	addEmptyTopLevelPermissions := false
 	exemptedActions, pinToImmutable, maintainedActionsMap := []string{}, false, map[string]string{}
 
 	if len(params) > 0 {
@@ -68,6 +69,10 @@ func SecureWorkflow(queryStringParams map[string]string, inputYaml string, svc d
 		enableLogging = true
 	}
 
+	if queryStringParams["addEmptyTopLevelPermissions"] == "true" {
+		addEmptyTopLevelPermissions = true
+	}
+
 	if enableLogging {
 		// Log query parameters
 		paramsJSON, _ := json.MarshalIndent(queryStringParams, "", "  ")
@@ -83,7 +88,7 @@ func SecureWorkflow(queryStringParams map[string]string, inputYaml string, svc d
 		if enableLogging {
 			log.Printf("Adding job level permissions")
 		}
-		secureWorkflowReponse, err = permissions.AddJobLevelPermissions(secureWorkflowReponse.FinalOutput)
+		secureWorkflowReponse, err = permissions.AddJobLevelPermissions(secureWorkflowReponse.FinalOutput, addEmptyTopLevelPermissions)
 		secureWorkflowReponse.OriginalInput = inputYaml
 		if err != nil {
 			if enableLogging {
@@ -95,7 +100,7 @@ func SecureWorkflow(queryStringParams map[string]string, inputYaml string, svc d
 				if enableLogging {
 					log.Printf("Adding workflow level permissions")
 				}
-				secureWorkflowReponse.FinalOutput, err = permissions.AddWorkflowLevelPermissions(secureWorkflowReponse.FinalOutput, addProjectComment)
+				secureWorkflowReponse.FinalOutput, err = permissions.AddWorkflowLevelPermissions(secureWorkflowReponse.FinalOutput, addProjectComment, addEmptyTopLevelPermissions)
 				if err != nil {
 					if enableLogging {
 						log.Printf("Error adding workflow level permissions: %v", err)

--- a/testfiles/joblevelpermskb/input/empty-top-level-permissions.yml
+++ b/testfiles/joblevelpermskb/input/empty-top-level-permissions.yml
@@ -1,0 +1,13 @@
+name: "checkout only workflow"
+
+on:
+  push:
+  
+
+jobs:
+  checkout-job:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3

--- a/testfiles/joblevelpermskb/output/empty-top-level-permissions.yml
+++ b/testfiles/joblevelpermskb/output/empty-top-level-permissions.yml
@@ -1,0 +1,15 @@
+name: "checkout only workflow"
+
+on:
+  push:
+  
+
+jobs:
+  checkout-job:
+    permissions:
+      contents: read  # for actions/checkout to fetch code
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3

--- a/testfiles/secureworkflow/input/empty-permissions.yml
+++ b/testfiles/secureworkflow/input/empty-permissions.yml
@@ -1,0 +1,12 @@
+on:
+  push:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Setup Node
+      uses: actions/setup-node@v1

--- a/testfiles/secureworkflow/output/empty-permissions.yml
+++ b/testfiles/secureworkflow/output/empty-permissions.yml
@@ -1,0 +1,21 @@
+on:
+  push:
+
+permissions: {}
+
+jobs:
+  test:
+    permissions:
+      contents: read  # for actions/checkout to fetch code
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Harden the runner (Audit all outbound calls)
+      uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
+      with:
+        egress-policy: audit
+
+    - name: Checkout
+      uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+    - name: Setup Node
+      uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1.4.6

--- a/testfiles/toplevelperms/input/empty-permissions.yml
+++ b/testfiles/toplevelperms/input/empty-permissions.yml
@@ -1,0 +1,9 @@
+name: "simple workflow"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Run test
+      run: echo "test"

--- a/testfiles/toplevelperms/output/empty-permissions.yml
+++ b/testfiles/toplevelperms/output/empty-permissions.yml
@@ -1,0 +1,11 @@
+name: "simple workflow"
+
+permissions: {}
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Run test
+      run: echo "test"


### PR DESCRIPTION
- Added new query parameter addEmptyTopLevelPermissions to control permission handling
- When set to true, adds empty permissions {} at workflow level
- When set to true, includes contents:read at job level even if it's the only permission
- Added tests for the new functionality
- Updated existing tests to handle the new parameter

This allows more flexible control over permission configuration for workflows that need specific empty permission patterns.